### PR TITLE
Increase MAX_POPULATION to 1000

### DIFF
--- a/src/genetics.rs
+++ b/src/genetics.rs
@@ -14,7 +14,7 @@ use rayon::iter::Zip;
 use rayon::prelude::*;
 use rayon::vec::IntoIter;
 
-pub const MAX_POPULATION: usize = 100;
+pub const MAX_POPULATION: usize = 1000;
 
 pub struct GAParams {
     population: usize,


### PR DESCRIPTION
I fooled around a bit with increasing the `MAX_POPULATION` value and saw some interesting results.

If we set `MAX_POPULATION` > ~12000, the main thread crashes with a stack overflow.

If we convert to passing `Box<ArrayVec<Board<N>, M>>` around, we can get `MAX_POPULATION` up to ~25000 before the main thread crashes with a stack overflow (intermediate portions were still on the stack).

It looks like the stack size of the main thread in Rust is 2 MiB and cannot be configured. As of right now the size of a `Board<9>` is 81 bytes (`u8` is 1 byte: https://doc.rust-lang.org/stable/std/mem/fn.size_of.html).

```rust
    println!(
        "Size of Board<9>: {} bytes",
        std::mem::size_of::<Board<9>>()
    );
    println!(
        "Size of ArrayVec<Board<9>, 12000>: {} bytes",
        std::mem::size_of::<ArrayVec<Board<9>, 12000>>()
    );
    println!(
        "Size of Box<ArrayVec<Board<9>, 25000>>: {} bytes",
        std::mem::size_of::<Box<ArrayVec<Board<9>, 25000>>>()
    );
```
```
Size of Board<9>: 81 bytes
Size of ArrayVec<Board<9>, 12000>: 972004 bytes
Size of Box<ArrayVec<Board<9>, 25000>>: 8 bytes
```

After running some tests I found that even with the changes to support higher max populations the duration to solve the default board increased. My guess is that the time to calculate fitness scores for that many potential solutions starts to add up so it may not be worth trying to move this off the stack and into the heap.

It seems that the "sweet spot" is something like a `MAX_POPULATION` of ~1000, with restarts every ~100 generations:

```
$ ./target/release/genetic-sudoku --population 1000 --restart 100 --bench boards/default.txt
Solution: Generation: 663 | Duration: 666.437031ms | Average Generation: 663 | Average Duration: 666.444607ms
Solution: Generation: 796 | Duration: 789.998654ms | Average Generation: 729 | Average Duration: 728.231262ms
Solution: Generation: 992 | Duration: 999.190223ms | Average Generation: 817 | Average Duration: 818.556332ms
Solution: Generation: 663 | Duration: 674.330506ms | Average Generation: 778 | Average Duration: 782.504018ms
Solution: Generation: 790 | Duration: 821.056312ms | Average Generation: 780 | Average Duration: 790.217942ms
```

This sweet spot may be specific the the default board, since using the same GA parameters for `boards/al-escargot.txt` still takes a significant time to solve (significant meaning I haven't run it long enough to produce a single solution because I don't want to run my laptop CPU hard non-stop).