### PR TITLE
rand_pcg

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 /.idea
 /target
+perf.data
+perf.data.old
+flamegraph.svg

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -204,6 +204,7 @@ dependencies = [
  "clap",
  "criterion",
  "rand",
+ "rand_pcg",
  "rayon",
  "static_assertions",
 ]
@@ -413,6 +414,15 @@ name = "rand_hc"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d51e9f596de227fda2ea6c84607f5558e196eeaf43c986b724ba4fb8fdf497e7"
+dependencies = [
+ "rand_core",
+]
+
+[[package]]
+name = "rand_pcg"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59cad018caf63deb318e5a4586d99a24424a364f40f1e5778c29aca23f4fc73e"
 dependencies = [
  "rand_core",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,9 @@ static_assertions = "1.1"
 [dev-dependencies]
 criterion = "0.3"
 
+[profile.release]
+debug = 1
+
 [[bench]]
 name = "sudoku"
 harness = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "genetic-sudoku"
 version = "0.1.0"
 edition = "2021"
 authors = ["Eric Wohltman <eric.wohltman@gmail.com>", "Bart Massey <bart@cs.pdx.edu>"]
-repository = "http://github.com/ewohltman/genetic-sudoku"
+repository = "https://github.com/ewohltman/genetic-sudoku"
 keywords = ["sudoku", "solver", "genetic algorithms"]
 categories = ["Algorithms", "Games"]
 description = "Genetic Algorithm Sudoku solver"
@@ -11,10 +11,11 @@ license-file = "LICENSE"
 
 [dependencies]
 arrayvec = "0.7"
-clap = "2.34.0"
+clap = "2.34"
 rayon = "1.5"
 rand = "0.8"
-static_assertions = "1.1.0"
+rand_pcg = "0.3"
+static_assertions = "1.1"
 
 [dev-dependencies]
 criterion = "0.3"

--- a/benches/sudoku.rs
+++ b/benches/sudoku.rs
@@ -8,6 +8,9 @@
 
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use genetic_sudoku::sudoku::{Board, Row};
+use rand::rngs::OsRng;
+use rand::{thread_rng, Rng, SeedableRng};
+use rand_pcg::Pcg64Mcg;
 
 const BAD_BOARD: Board<4> = Board([
     Row([1, 2, 3, 4]),
@@ -18,19 +21,37 @@ const BAD_BOARD: Board<4> = Board([
 
 fn bench_count_row_duplicates(c: &mut Criterion) {
     c.bench_function("count_row_duplicates", |b| {
-        b.iter(|| black_box(BAD_BOARD).count_row_duplicates());
+        b.iter(|| black_box(BAD_BOARD.count_row_duplicates()));
     });
 }
 
 fn bench_count_box_duplicates(c: &mut Criterion) {
     c.bench_function("count_box_duplicates", |b| {
-        b.iter(|| black_box(BAD_BOARD).count_box_duplicates());
+        b.iter(|| black_box(BAD_BOARD.count_box_duplicates()));
+    });
+}
+
+fn bench_thread_rng(c: &mut Criterion) {
+    let mut rng = thread_rng();
+
+    c.bench_function("thread_rng", |b| {
+        b.iter(|| black_box(rng.gen::<f32>()));
+    });
+}
+
+fn bench_pcg64mcg(c: &mut Criterion) {
+    let mut rng = Pcg64Mcg::from_rng(OsRng).unwrap();
+
+    c.bench_function("thread_rng", |b| {
+        b.iter(|| black_box(rng.gen::<f32>()));
     });
 }
 
 criterion_group!(
     benches,
     bench_count_row_duplicates,
-    bench_count_box_duplicates
+    bench_count_box_duplicates,
+    bench_thread_rng,
+    bench_pcg64mcg,
 );
 criterion_main!(benches);

--- a/benches/sudoku.rs
+++ b/benches/sudoku.rs
@@ -21,13 +21,13 @@ const BAD_BOARD: Board<4> = Board([
 
 fn bench_count_row_duplicates(c: &mut Criterion) {
     c.bench_function("count_row_duplicates", |b| {
-        b.iter(|| black_box(BAD_BOARD.count_row_duplicates()));
+        b.iter(|| black_box(BAD_BOARD).count_row_duplicates());
     });
 }
 
 fn bench_count_box_duplicates(c: &mut Criterion) {
     c.bench_function("count_box_duplicates", |b| {
-        b.iter(|| black_box(BAD_BOARD.count_box_duplicates()));
+        b.iter(|| black_box(BAD_BOARD).count_box_duplicates());
     });
 }
 
@@ -35,7 +35,7 @@ fn bench_thread_rng(c: &mut Criterion) {
     let mut rng = thread_rng();
 
     c.bench_function("thread_rng", |b| {
-        b.iter(|| black_box(rng.gen::<f32>()));
+        b.iter(|| black_box(&mut rng).gen::<f32>());
     });
 }
 
@@ -43,7 +43,7 @@ fn bench_pcg64mcg(c: &mut Criterion) {
     let mut rng = Pcg64Mcg::from_rng(OsRng).unwrap();
 
     c.bench_function("Pcg64Mcg", |b| {
-        b.iter(|| black_box(rng.gen::<f32>()));
+        b.iter(|| black_box(&mut rng).gen::<f32>());
     });
 }
 

--- a/benches/sudoku.rs
+++ b/benches/sudoku.rs
@@ -42,7 +42,7 @@ fn bench_thread_rng(c: &mut Criterion) {
 fn bench_pcg64mcg(c: &mut Criterion) {
     let mut rng = Pcg64Mcg::from_rng(OsRng).unwrap();
 
-    c.bench_function("thread_rng", |b| {
+    c.bench_function("Pcg64Mcg", |b| {
         b.iter(|| black_box(rng.gen::<f32>()));
     });
 }

--- a/src/genetics.rs
+++ b/src/genetics.rs
@@ -9,7 +9,9 @@
 use super::errors::NoSolutionFound;
 use super::sudoku::{Board, Row};
 use arrayvec::ArrayVec;
-use rand::{distributions::Uniform, thread_rng, Rng};
+use rand::rngs::OsRng;
+use rand::{distributions::Uniform, Rng, SeedableRng};
+use rand_pcg::Pcg64Mcg;
 use rayon::iter::Zip;
 use rayon::prelude::*;
 use rayon::vec::IntoIter;
@@ -82,8 +84,8 @@ pub fn generate_initial_population<const N: usize, const M: usize>(
 ) -> ArrayVec<Board<N>, M> {
     let max_digit = u8::try_from(N).expect("digit size exceeds 255");
     let range = Uniform::from(1..=max_digit);
-    let mut rng = thread_rng();
     let mut boards: ArrayVec<Board<N>, M> = ArrayVec::new_const();
+    let mut rng = Pcg64Mcg::from_rng(OsRng).unwrap();
 
     for _ in 0..params.population {
         let mut board: ArrayVec<Row<N>, N> = ArrayVec::new_const();
@@ -218,8 +220,8 @@ fn make_children<const N: usize, const M: usize>(
     let max_digit = u8::try_from(N).expect("digit size exceeds 255");
     let inherits_from_range: Uniform<u8> = Uniform::from(0..=1);
     let mutation_values_range: Uniform<u8> = Uniform::from(1..=max_digit);
-    let mut rng = thread_rng();
     let mut children: ArrayVec<Board<N>, M> = ArrayVec::new_const();
+    let mut rng = Pcg64Mcg::from_rng(OsRng).unwrap();
 
     for _ in 0..params.num_children_per_parent_pairs {
         let mut child: ArrayVec<Row<N>, N> = ArrayVec::new_const();

--- a/src/main.rs
+++ b/src/main.rs
@@ -62,14 +62,14 @@ fn parse_args() -> Result<(PathBuf, GAParams, bool), Box<dyn std::error::Error>>
 
     let path = Path::new(matches.value_of("BOARD").unwrap()).to_owned();
     let population = matches.value_of("population").unwrap_or("100").parse()?;
-    let selection = matches.value_of("selection").unwrap_or("0.5").parse()?;
-    let mutation = matches.value_of("mutation").unwrap_or("0.05").parse()?;
+    let selection_rate = matches.value_of("selection").unwrap_or("0.5").parse()?;
+    let mutation_rate = matches.value_of("mutation").unwrap_or("0.05").parse()?;
     let restart = match matches.value_of("restart") {
         None => None,
         Some(restart) => Some(restart.parse()?),
     };
     let benchmark = matches.is_present("bench");
-    let params = GAParams::new(population, selection, mutation, restart);
+    let params = GAParams::new(population, selection_rate, mutation_rate, restart);
 
     Ok((path, params, benchmark))
 }


### PR DESCRIPTION
The main part of this change moves us away from using `thread_rng` to `Pcg64Mcg` from the `rand_pcg` crate. From https://docs.rs/rand_pcg/latest/rand_pcg/:

> `Pcg64Mcg` aka `Mcg128Xsl64`, officially known as `pcg64_fast`, a general purpose RNG using 128-bit multiplications. This has poor performance on 32-bit CPUs but is a good choice on 64-bit CPUs for both 32-bit and 64-bit output.

This results in faster random number generation as seen from benchmarks (lines omitted for brevity):

```
thread_rng              time:   [3.5544 ns 3.5838 ns 3.6230 ns]
Pcg64Mcg                time:   [3.0384 ns 3.0460 ns 3.0574 ns]
```