### PR TITLE
Vec

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -16,6 +16,7 @@ pub struct NoSolutionFound<const N: usize> {
 }
 
 impl<const N: usize> Display for NoSolutionFound<N> {
+    #[inline]
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         Debug::fmt(self, f)
     }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -7,19 +7,18 @@
 )]
 
 use super::sudoku::Board;
-use arrayvec::ArrayVec;
 use std::error::Error;
 use std::fmt::{Debug, Display, Formatter};
 
 #[derive(Debug)]
-pub struct NoSolutionFound<const N: usize, const M: usize> {
-    pub next_generation: ArrayVec<Board<N>, M>,
+pub struct NoSolutionFound<const N: usize> {
+    pub next_generation: Vec<Board<N>>,
 }
 
-impl<const N: usize, const M: usize> Display for NoSolutionFound<N, M> {
+impl<const N: usize> Display for NoSolutionFound<N> {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         Debug::fmt(self, f)
     }
 }
 
-impl<const N: usize, const M: usize> Error for NoSolutionFound<N, M> {}
+impl<const N: usize> Error for NoSolutionFound<N> {}

--- a/src/genetics.rs
+++ b/src/genetics.rs
@@ -16,7 +16,7 @@ use rayon::iter::Zip;
 use rayon::prelude::*;
 use rayon::vec::IntoIter;
 
-pub const MAX_POPULATION: usize = 1000;
+pub const MAX_POPULATION: usize = 100_000;
 
 pub struct GAParams {
     population: usize,
@@ -81,11 +81,11 @@ impl GAParams {
 #[must_use]
 pub fn generate_initial_population<const N: usize, const M: usize>(
     params: &GAParams,
-) -> ArrayVec<Board<N>, M> {
+) -> Vec<Board<N>> {
     let max_digit = u8::try_from(N).expect("digit size exceeds 255");
-    let range = Uniform::from(1..=max_digit);
-    let mut boards: ArrayVec<Board<N>, M> = ArrayVec::new_const();
+    let values_range = Uniform::from(1..=max_digit);
     let mut rng = Pcg64Mcg::from_rng(OsRng).unwrap();
+    let mut boards: Vec<Board<N>> = Vec::with_capacity(M);
 
     for _ in 0..params.population {
         let mut board: ArrayVec<Row<N>, N> = ArrayVec::new_const();
@@ -94,7 +94,7 @@ pub fn generate_initial_population<const N: usize, const M: usize>(
             let mut row: ArrayVec<u8, N> = ArrayVec::new_const();
 
             for _ in 0..N {
-                row.push(rng.sample(range));
+                row.push(rng.sample(values_range));
             }
 
             board.push(Row(row.into_inner().unwrap()));
@@ -127,12 +127,12 @@ pub fn run_simulation<const N: usize, const M: usize>(
     params: &GAParams,
     generation: u64,
     base: &Board<N>,
-    population: ArrayVec<Board<N>, M>,
-) -> Result<Board<N>, NoSolutionFound<N, M>> {
+    population: Vec<Board<N>>,
+) -> Result<Board<N>, NoSolutionFound<N>> {
     let population_scores: Result<Vec<(Board<N>, u8)>, Board<N>> = population
         .into_par_iter()
         .map(|candidate| -> Result<(Board<N>, u8), Board<N>> {
-            let solution = base.overlay(candidate);
+            let solution = base.overlay(&candidate);
             let score = solution.fitness();
             if score == 0 {
                 Err(solution)
@@ -141,13 +141,11 @@ pub fn run_simulation<const N: usize, const M: usize>(
             }
         })
         .collect();
-    drop(population);
 
     match population_scores {
         Err(valid_solution) => Ok(valid_solution),
-        Ok(population) => {
-            let candidates: ArrayVec<(Board<N>, u8), M> = population.into_iter().collect();
-            let next_generation = next_generation(params, generation, candidates);
+        Ok(population_scores) => {
+            let next_generation = next_generation::<N, M>(params, generation, population_scores);
             Err(NoSolutionFound { next_generation })
         }
     }
@@ -156,52 +154,45 @@ pub fn run_simulation<const N: usize, const M: usize>(
 fn next_generation<const N: usize, const M: usize>(
     params: &GAParams,
     generation: u64,
-    population_scores: ArrayVec<(Board<N>, u8), M>,
-) -> ArrayVec<Board<N>, M> {
+    population_scores: Vec<(Board<N>, u8)>,
+) -> Vec<Board<N>> {
     if let Some(restart) = params.restart {
         if (generation % restart == 0) && (generation != 0) {
-            return generate_initial_population(params);
+            return generate_initial_population::<N, M>(params);
         }
     }
 
-    ArrayVec::from_iter(
-        make_parents(natural_selection(params, population_scores))
-            .flat_map(|parents| make_children::<N, M>(params, parents))
-            .collect::<Vec<Board<N>>>(),
-    )
+    make_parents(natural_selection(params, population_scores))
+        .flat_map(|parents| make_children::<N, M>(params, parents))
+        .collect()
 }
 
-fn natural_selection<const N: usize, const M: usize>(
+fn natural_selection<const N: usize>(
     params: &GAParams,
-    mut population_scores: ArrayVec<(Board<N>, u8), M>,
-) -> ArrayVec<Board<N>, M> {
+    mut population_scores: Vec<(Board<N>, u8)>,
+) -> Vec<Board<N>> {
     population_scores.par_sort_unstable_by_key(|(_, score)| *score);
 
-    ArrayVec::from_iter(
-        population_scores
-            .drain(..params.num_survivors)
-            .collect::<Vec<(Board<N>, u8)>>()
-            .into_par_iter()
-            .map(|(survivor, _)| survivor)
-            .collect::<Vec<Board<N>>>(),
-    )
+    population_scores
+        .drain(..params.num_survivors)
+        .map(|(survivor, _)| survivor)
+        .collect()
 }
 
-fn make_parents<const N: usize, const M: usize>(
-    survivors: ArrayVec<Board<N>, M>,
+fn make_parents<const N: usize>(
+    survivors: Vec<Board<N>>,
 ) -> Zip<IntoIter<Board<N>>, IntoIter<Board<N>>> {
     let parents: (Vec<Option<Board<N>>>, Vec<Option<Board<N>>>) = survivors
         .into_par_iter()
         .enumerate()
         .map(|(i, survivor)| -> (Option<Board<N>>, Option<Board<N>>) {
             match i % 2 {
-                0 => (Some(*survivor), None),
-                1 => (None, Some(*survivor)),
+                0 => (Some(survivor), None),
+                1 => (None, Some(survivor)),
                 _ => (None, None),
             }
         })
         .collect();
-    drop(survivors);
 
     let parents_x = parents
         .0
@@ -228,7 +219,7 @@ fn make_children<const N: usize, const M: usize>(
     let Board(parent_y) = parents.1;
 
     let max_digit = u8::try_from(N).expect("digit size exceeds 255");
-    let mutation_values_range: Uniform<u8> = Uniform::from(1..=max_digit);
+    let values_range: Uniform<u8> = Uniform::from(1..=max_digit);
     let mutation_rate = f64::from(params.mutation_rate);
     let mut rng = Pcg64Mcg::from_rng(OsRng).unwrap();
     let mut children: Vec<Board<N>> = Vec::with_capacity(M);
@@ -243,7 +234,7 @@ fn make_children<const N: usize, const M: usize>(
 
             for j in 0..N {
                 if rng.gen_bool(mutation_rate) {
-                    child_values.push(rng.sample(mutation_values_range));
+                    child_values.push(rng.sample(values_range));
                     continue;
                 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -90,7 +90,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         let mut population = generate_initial_population::<BOARD_SIZE, MAX_POPULATION>(&params);
 
         loop {
-            population = match run_simulation(&params, generation, &board, population) {
+            population = match run_simulation::<BOARD_SIZE, MAX_POPULATION>(
+                &params, generation, &board, population,
+            ) {
                 Ok(solution) => {
                     total_generations += generation;
 

--- a/src/sudoku.rs
+++ b/src/sudoku.rs
@@ -203,6 +203,7 @@ impl<const N: usize> Board<N> {
     /// # Errors
     ///
     /// Fails if file is nonexistent, unreadable, or of the wrong size.
+    #[inline]
     pub fn read<P: AsRef<std::path::Path>>(path: P) -> Result<Self, std::io::Error> {
         let board = std::fs::read_to_string(path)?;
         let format_error =


### PR DESCRIPTION
This change moves most of the usages of `ArrayVec` to regular `Vec`, keeping some of the usages of `ArrayVec` where it's convenient to convert them into arrays.

Some investigation with `perf` + https://github.com/flamegraph-rs/flamegraph showed that a large chunk of time spent was in the `make_children` function, so I changed it to generate the children in parallel.